### PR TITLE
Include any modules with a defined `spec` function

### DIFF
--- a/src/Test/Spec/Discovery.js
+++ b/src/Test/Spec/Discovery.js
@@ -13,7 +13,7 @@ function getMatchingModules(pattern) {
     return (new RegExp(pattern).test(directory));
   }).map(function (name) {
     var module = require(path.join(__dirname, '..', name));
-    return (module && typeof module.spec === 'function') ? module.spec : null;
+    return (module && typeof module.spec !== 'undefined') ? module.spec : null;
   }).filter(function (x) { return x; });
 }
 


### PR DESCRIPTION
In purescript-spec 4.0.0, the spec function's type is 'object' rather
than 'function'. This change allows discovery to work with all versions
of purescript-spec.

Closes #12