### PR TITLE
Make discover work with all `MonadEffect`s

### DIFF
--- a/src/Test/Spec/Discovery.purs
+++ b/src/Test/Spec/Discovery.purs
@@ -4,11 +4,12 @@ import Prelude
 
 import Data.Traversable (sequence_)
 import Effect (Effect)
+import Effect.Class (class MonadEffect, liftEffect)
 import Test.Spec (Spec)
 
 foreign import getSpecs :: String
                         -> Effect (Array (Spec Unit))
 
-discover :: String
-         -> Effect (Spec Unit)
-discover pattern = getSpecs pattern >>= (pure <<< sequence_)
+discover :: forall m. MonadEffect m => String
+         -> m (Spec Unit)
+discover pattern = getSpecs pattern >>= (pure <<< sequence_) # liftEffect


### PR DESCRIPTION
`purescript-spec` 4.0.0 moves to `Aff`. This change allows the discover
function to work with both `Effect` and `Aff`, making it ergonomic for all
versions of `purescript-spec`.