### PR TITLE
Use triple quotes in README.md for regex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import Test.Spec.Runner (run)
 
 main :: Effect Unit
 main = launchAff_ do
-  specs <- discover "My\\.Package\\..*Spec"
+  specs <- discover """My\.Package\..*Spec"""
   run [consoleReporter] specs
 ```
 
@@ -43,7 +43,7 @@ import Test.Spec.Runner (run)
 
 main :: Effect Unit
 main = do
-  specs <- discover "My\\.Package\\..*Spec"
+  specs <- discover """My\.Package\..*Spec"""
   run [consoleReporter] specs
 ```
 


### PR DESCRIPTION
The [typescript syntax doc](https://github.com/purescript/documentation/blob/master/language/Syntax.md?ts=2#triple-quote-strings) suggests using triple quotes for regexes for readability.