### PR TITLE
Use `runSpec` instead of `run` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Spec.Discovery (discover)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
 main = launchAff_ do
   specs <- discover "My\\.Package\\..*Spec"
-  run [consoleReporter] specs
+  runSpec [consoleReporter] specs
 ```
 
 For older versions of `purescript-spec`:
@@ -39,12 +39,12 @@ import Prelude
 import Effect (Effect)
 import Test.Spec.Discovery (discover)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
 main = do
   specs <- discover "My\\.Package\\..*Spec"
-  run [consoleReporter] specs
+  runSpec [consoleReporter] specs
 ```
 
 All modules that match the regular expression, **and has a definition


### PR DESCRIPTION
Spec changed the name of `run` to `runSpec` and deprecated the former as of version 4.0.0:
https://github.com/purescript-spec/purescript-spec?ts=2#changelog