### PR TITLE
Update bower.json for PureScript 0.15

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,10 +12,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^5.0.0",
-    "purescript-effect": "^3.0.0",
-    "purescript-arrays": "^6.0.0",
-    "purescript-spec": "^5.0.0",
-    "purescript-node-fs": "^6.0.0"
+    "purescript-prelude": "^6.0.0",
+    "purescript-effect": "^4.0.0",
+    "purescript-arrays": "^7.0.0",
+    "purescript-spec": "^7.0.0",
+    "purescript-node-fs": "^8.0.0"
   }
 }


### PR DESCRIPTION
The PureScript 0.15 update left out the Bower file.