### PR TITLE
feat: better output -> wrap each spec in describe

### DIFF
--- a/src/Test/Spec/Discovery.js
+++ b/src/Test/Spec/Discovery.js
@@ -23,7 +23,7 @@ export function getSpecs(pattern) {
           ? path.join('file://', __dirname, '..', name, 'index.js')
           : path.join(__dirname, '..', name, 'index.js')
         return import(fullPath).then(module =>
-          module && typeof module.spec !== 'undefined' ? module.spec : null
+          module && typeof module.spec !== 'undefined' ? { name, spec: module.spec } : null
         )
       })
 

--- a/src/Test/Spec/Discovery.purs
+++ b/src/Test/Spec/Discovery.purs
@@ -1,8 +1,7 @@
 module Test.Spec.Discovery
   ( discover
   , discoverAndRunSpecs
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -12,17 +11,18 @@ import Effect.Aff (launchAff_)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Aff.Compat (EffectFn1, EffectFnAff, fromEffectFnAff, runEffectFn1)
 import Effect.Class (liftEffect)
-import Test.Spec (Spec)
+import Test.Spec (Spec, describe)
 import Test.Spec.Runner (Reporter)
 import Test.Spec.Runner.Node (runSpecAndExitProcess)
 
-foreign import getSpecs :: EffectFn1 String (EffectFnAff (Array (Spec Unit)))
+foreign import getSpecs :: EffectFn1 String (EffectFnAff (Array { name :: String, spec :: Spec Unit }))
 
 discover :: ∀ m. MonadAff m => String -> m (Spec Unit)
 discover pattern = do
   runDiscover <- liftEffect $ runEffectFn1 getSpecs pattern
   specs <- liftAff $ fromEffectFnAff runDiscover
-  pure $ sequence_ specs
+  let specsWrappedInDescribe = map (\{ name, spec } -> describe name spec) specs
+  pure $ sequence_ specsWrappedInDescribe
 
 discoverAndRunSpecs :: Array Reporter -> String -> Effect Unit
 discoverAndRunSpecs reporters pattern = launchAff_ do


### PR DESCRIPTION
before

```
Running tests for package: record-extra-srghma
appendRecord
  ✓︎ appends overlapping subrecords with Semigroup values (String)
  ✓︎ appends with numeric values using addition
  ✓︎ does nothing when smaller is empty
CompareRecordTests
  ✓︎ compares two records deterministically
FoldlValuesTests
  ✓︎ foldlValues
  ✓︎ foldlValues1

```

after

```
Running tests for package: record-extra-srghma
Test.Tests.AppendRecordSpec » appendRecord
  ✓︎ appends overlapping subrecords with Semigroup values (String)
  ✓︎ appends with numeric values using addition
  ✓︎ does nothing when smaller is empty
Test.Tests.CompareRecordSpec » CompareRecordTests
  ✓︎ compares two records deterministically
Test.Tests.FoldlValuesSpec » FoldlValuesTests
  ✓︎ foldlValues
  ✓︎ foldlValues1

```